### PR TITLE
Release v1.0.64

### DIFF
--- a/changelog.adoc
+++ b/changelog.adoc
@@ -2,6 +2,16 @@
 
 === Released
 
+==== v1.0.64 (2022-05-16)
+
+===== Added
+
+- The common response builder - `tenet.response/as`
+
+===== Fixed
+
+- Removed the helper function `cl-format` for the ability to work with GraalVM
+
 ==== v1.0.57 (2022-04-30)
 
 Public API is stable.

--- a/deps.edn
+++ b/deps.edn
@@ -6,7 +6,7 @@
                               :jvm-opts    ["-server" "-Xmx4096m" "-Dclojure.compiler.direct-linking=true"]}
 
            :develop          {:extra-paths ["src/develop/clojure" "src/develop/resources"]
-                              :extra-deps  {org.clojure/clojurescript {:mvn/version "1.11.4"}
+                              :extra-deps  {org.clojure/clojurescript {:mvn/version "1.11.51"}
                                             criterium/criterium       {:mvn/version "0.4.6"}
                                             cider/piggieback          {:mvn/version "0.5.3"}
                                             nrepl/nrepl               {:mvn/version "0.9.0"}
@@ -30,7 +30,7 @@
 
            :nop              {:extra-deps {org.slf4j/slf4j-nop {:mvn/version "1.7.36"}}}
 
-           :outdated         {:extra-deps {com.github.liquidz/antq {:mvn/version "1.6.1"}}
+           :outdated         {:extra-deps {com.github.liquidz/antq {:mvn/version "1.6.2"}}
                               :main-opts  ["--main" "antq.core"]}
 
            :outdated/upgrade {:main-opts ["--main" "antq.core" "--upgrade" "--force"]}}}

--- a/readme.adoc
+++ b/readme.adoc
@@ -96,13 +96,13 @@ Add the following dependency in your project:
 .project.clj or build.boot
 [source,clojure]
 ----
-[io.lazy-cat/tenet "1.0.57"]
+[io.lazy-cat/tenet "1.0.64"]
 ----
 
 .deps.edn or bb.edn
 [source,clojure]
 ----
-io.lazy-cat/tenet {:mvn/version "1.0.57"}
+io.lazy-cat/tenet {:mvn/version "1.0.64"}
 ----
 
 ==== Basic API
@@ -165,6 +165,21 @@ io.lazy-cat/tenet {:mvn/version "1.0.57"}
 (r/as-found x)
 (r/as-success x)
 (r/as-updated x)
+----
+
+===== Custom response builders
+
+[source,clojure]
+----
+
+(derive :org.acme.user/incorrect ::r/error) ;; or (swap! r/*registry conj :org.acme.user/incorrect)
+
+(r/as :org.acme.user/incorrect :foo) ;; => #tenet [:org.acme.user/incorrect :foo]
+(-> (r/as :org.acme.user/incorrect) (r/anomaly?)) ;; => true
+(-> (r/as :org.acme.user/incorrect :foo) (r/anomaly?)) ;; => true
+
+(r/as :org.acme.user/created :foo) ;; => #tenet [:org.acme.user/created :foo]
+(-> (r/as :org.acme.user/created :foo) (r/anomaly?)) ;; => false
 ----
 
 ==== Examples

--- a/src/main/clojure/tenet/response.cljc
+++ b/src/main/clojure/tenet/response.cljc
@@ -2,8 +2,7 @@
   (:refer-clojure :exclude [format type -> ->>])
   #?@(:clj
       [(:require
-         [clojure.core :as c]
-         [clojure.pprint :as pprint])
+         [clojure.core :as c])
        (:import
          (clojure.lang
            Associative
@@ -17,7 +16,6 @@
            Writer))]
       :cljs
       [(:require
-         [cljs.pprint :as pprint]
          [goog.string :as gstr]
          [goog.string.format])
        (:require-macros
@@ -32,12 +30,6 @@
   "Formats a string."
   #?(:clj  c/format
      :cljs gstr/format))
-
-
-;; TODO: [2022-04-23, ilshat@sultanov.team] Need to check working or not with GraalVM?
-(def cl-format
-  "An implementation of a Common Lisp compatible format function."
-  pprint/cl-format)
 
 
 
@@ -172,7 +164,7 @@
          (case key
            :type (Response. new-value data _meta)
            :data (Response. type new-value _meta)
-           (throw (IllegalArgumentException. ^String (cl-format nil "Response has no field for key - `~s`" key)))))
+           (throw (IllegalArgumentException. ^String (format "Response has no field for key - `%s`" (if (some? key) key "nil"))))))
 
        IPersistentCollection
        (equiv [_ other]
@@ -184,7 +176,9 @@
 
        Object
        (toString [_]
-         (cl-format nil "[~s ~s]" type data))
+         (if (some? data)
+           (format "[%s %s]" type data)
+           (format "[%s nil]" type)))
        (equals [_ other]
          (and (response? other)
               (= type (:type other))
@@ -255,11 +249,13 @@
        (case key
          :type (Response. new-value data _meta)
          :data (Response. type new-value _meta)
-         (throw (js/Error. (cl-format nil "Response has no field for key - `~s`" key)))))
+         (throw (js/Error. (format "Response has no field for key - `%s`" (if (some? key) key "nil"))))))
 
      Object
      (toString [_]
-       (cl-format nil "[~s ~s]" type data))
+       (if (some? data)
+         (format "[%s %s]" type data)
+         (format "[%s nil]" type)))
 
      IEquiv
      (-equiv [_ other]
@@ -328,7 +324,6 @@
      (boolean (:ns env))))
 
 
-;; TODO: add finally? [body handler finally]
 #?(:clj
    (defmacro safe
      "Extended version of try-catch."

--- a/src/main/clojure/tenet/response.cljc
+++ b/src/main/clojure/tenet/response.cljc
@@ -385,6 +385,15 @@
 ;; Response builders
 ;;
 
+;; Common response builder
+
+(defn as
+  ([type]
+   (as-response nil type))
+  ([type data]
+   (as-response data type)))
+
+
 ;; Error response builders
 
 (defn as-busy

--- a/src/test/clojure/tenet/response_test.cljc
+++ b/src/test/clojure/tenet/response_test.cljc
@@ -358,6 +358,15 @@
 
 
 (deftest response-builders-test
+  (testing "common response builders"
+    (is (= true (sut/anomaly? (sut/as :error 42)) (sut/anomaly? (sut/as :error))))
+    (is (= false (sut/anomaly? (sut/as :success 42)) (sut/anomaly? (sut/as :success))))
+    (derive :org.acme.user/incorrect ::sut/error)
+    (is (= true (sut/anomaly? (sut/as :org.acme.user/incorrect 42)) (sut/anomaly? (sut/as :org.acme.user/incorrect))))
+    (is (= false (sut/anomaly? (sut/as :org.acme.user/created 42)) (sut/anomaly? (sut/as :org.acme.user/created))))
+    (underive :org.acme.user/incorrect ::sut/error))
+
+
   (testing "error response builders"
     (is (= true (sut/anomaly? (sut/as-busy)) (sut/anomaly? (sut/as-busy 42))))
     (is (= (sut/as-response nil :busy) (sut/as-busy)))


### PR DESCRIPTION
#### v1.0.64 (2022-05-16)

##### Added

- The common response builder - `tenet.response/as`

##### Fixed

- Removed the helper function `cl-format` for the ability to work with GraalVM