### PR TITLE
Release v1.0.67

### DIFF
--- a/changelog.adoc
+++ b/changelog.adoc
@@ -2,6 +2,12 @@
 
 === Released
 
+==== v1.0.67 (2022-05-16)
+
+===== Fixed
+
+- After some research, the removal of the helper function `cl-format` was reverted
+
 ==== v1.0.64 (2022-05-16)
 
 ===== Added

--- a/readme.adoc
+++ b/readme.adoc
@@ -96,13 +96,13 @@ Add the following dependency in your project:
 .project.clj or build.boot
 [source,clojure]
 ----
-[io.lazy-cat/tenet "1.0.64"]
+[io.lazy-cat/tenet "1.0.67"]
 ----
 
 .deps.edn or bb.edn
 [source,clojure]
 ----
-io.lazy-cat/tenet {:mvn/version "1.0.64"}
+io.lazy-cat/tenet {:mvn/version "1.0.67"}
 ----
 
 === Limitations

--- a/readme.adoc
+++ b/readme.adoc
@@ -105,6 +105,10 @@ Add the following dependency in your project:
 io.lazy-cat/tenet {:mvn/version "1.0.64"}
 ----
 
+=== Limitations
+
+This library doesn't work with babashka (sci) - currently `deftype` is not supported.
+
 ==== Basic API
 
 [source,clojure]

--- a/src/main/clojure/tenet/response.cljc
+++ b/src/main/clojure/tenet/response.cljc
@@ -34,7 +34,6 @@
      :cljs gstr/format))
 
 
-;; TODO: [2022-04-23, ilshat@sultanov.team] Need to check working or not with GraalVM?
 (def cl-format
   "An implementation of a Common Lisp compatible format function."
   pprint/cl-format)
@@ -119,6 +118,8 @@
 ;;
 ;; Response
 ;;
+
+;; TODO: [2022-05-16, ilshat@sultanov.team] Doesn't work with babashka (sci) `deftype` is not supported
 
 #?(:clj
    (do

--- a/src/main/clojure/tenet/response.cljc
+++ b/src/main/clojure/tenet/response.cljc
@@ -2,7 +2,8 @@
   (:refer-clojure :exclude [format type -> ->>])
   #?@(:clj
       [(:require
-         [clojure.core :as c])
+         [clojure.core :as c]
+         [clojure.pprint :as pprint])
        (:import
          (clojure.lang
            Associative
@@ -16,6 +17,7 @@
            Writer))]
       :cljs
       [(:require
+         [cljs.pprint :as pprint]
          [goog.string :as gstr]
          [goog.string.format])
        (:require-macros
@@ -30,6 +32,12 @@
   "Formats a string."
   #?(:clj  c/format
      :cljs gstr/format))
+
+
+;; TODO: [2022-04-23, ilshat@sultanov.team] Need to check working or not with GraalVM?
+(def cl-format
+  "An implementation of a Common Lisp compatible format function."
+  pprint/cl-format)
 
 
 
@@ -164,7 +172,7 @@
          (case key
            :type (Response. new-value data _meta)
            :data (Response. type new-value _meta)
-           (throw (IllegalArgumentException. ^String (format "Response has no field for key - `%s`" (if (some? key) key "nil"))))))
+           (throw (IllegalArgumentException. ^String (cl-format nil "Response has no field for key - `~s`" key)))))
 
        IPersistentCollection
        (equiv [_ other]
@@ -176,9 +184,7 @@
 
        Object
        (toString [_]
-         (if (some? data)
-           (format "[%s %s]" type data)
-           (format "[%s nil]" type)))
+         (cl-format nil "[~s ~s]" type data))
        (equals [_ other]
          (and (response? other)
               (= type (:type other))
@@ -249,13 +255,11 @@
        (case key
          :type (Response. new-value data _meta)
          :data (Response. type new-value _meta)
-         (throw (js/Error. (format "Response has no field for key - `%s`" (if (some? key) key "nil"))))))
+         (throw (js/Error. (cl-format nil "Response has no field for key - `~s`" key)))))
 
      Object
      (toString [_]
-       (if (some? data)
-         (format "[%s %s]" type data)
-         (format "[%s nil]" type)))
+       (cl-format nil "[~s ~s]" type data))
 
      IEquiv
      (-equiv [_ other]
@@ -324,6 +328,7 @@
      (boolean (:ns env))))
 
 
+;; TODO: add finally? [body handler finally]
 #?(:clj
    (defmacro safe
      "Extended version of try-catch."


### PR DESCRIPTION
#### v1.0.67 (2022-05-16)

##### Fixed

- After some research, the removal of the helper function `cl-format` was reverted